### PR TITLE
Revamp BIP32 API

### DIFF
--- a/bitcoin/examples/bip32.rs
+++ b/bitcoin/examples/bip32.rs
@@ -2,12 +2,11 @@ extern crate bitcoin;
 
 use std::{env, process};
 
-use bitcoin::address::{Address, KnownHrp};
-use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv, Xpub};
+use bitcoin::bip32::{DerivationPath, NormalDerivationPath, Xpriv, Xpub};
 use bitcoin::hex::FromHex;
 use bitcoin::secp256k1::ffi::types::AlignedType;
 use bitcoin::secp256k1::Secp256k1;
-use bitcoin::{CompressedPublicKey, NetworkKind};
+use bitcoin::{Address, CompressedPublicKey, KnownHrp, NetworkKind};
 
 fn main() {
     // This example derives root xprv from a 32-byte seed,
@@ -46,9 +45,10 @@ fn main() {
     println!("Public key at {}: {}", path, xpub);
 
     // generate first receiving address at m/0/0
-    // manually creating indexes this time
-    let zero = ChildNumber::ZERO_NORMAL;
-    let public_key = xpub.derive_xpub(&secp, &[zero, zero]).unwrap().public_key;
+    let zero_path = "0/0".parse::<NormalDerivationPath>().unwrap();
+    // While using only Normal Child Numbers, you can use NormalDerivationPath instead of DerivationPath
+    let public_key = xpub.derive_xpub(&secp, &zero_path).public_key;
+
     let address = Address::p2wpkh(CompressedPublicKey(public_key), KnownHrp::Mainnet);
     println!("First receiving address: {}", address);
 }

--- a/bitcoin/examples/ecdsa-psbt-simple.rs
+++ b/bitcoin/examples/ecdsa-psbt-simple.rs
@@ -25,7 +25,7 @@
 use std::collections::BTreeMap;
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
-use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
+use bitcoin::bip32::{ChildKeyIndex, DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::Input;
 use bitcoin::secp256k1::{Secp256k1, Signing};
@@ -58,13 +58,13 @@ fn get_external_address_xpriv<C: Signing>(
     master_xpriv: Xpriv,
     index: u32,
 ) -> Xpriv {
-    let derivation_path =
-        BIP84_DERIVATION_PATH.into_derivation_path().expect("valid derivation path");
-    let child_xpriv = master_xpriv.derive_xpriv(secp, &derivation_path);
-    let external_index = ChildNumber::ZERO_NORMAL;
-    let idx = ChildNumber::from_normal_idx(index).expect("valid index number");
+    let derivation_path = BIP84_DERIVATION_PATH.parse::<DerivationPath>().expect("valid path");
+    let child_xpriv = master_xpriv.derive_priv(secp, &derivation_path);
+    let external_index = ChildKeyIndex::ZERO_NORMAL;
+    let idx = ChildKeyIndex::from_normal_index(index).expect("valid index number");
 
-    child_xpriv.derive_xpriv(secp, &[external_index, idx])
+    child_xpriv.derive_priv(secp, [external_index, idx])
+
 }
 
 // Derive the internal address xpriv.
@@ -73,13 +73,14 @@ fn get_internal_address_xpriv<C: Signing>(
     master_xpriv: Xpriv,
     index: u32,
 ) -> Xpriv {
-    let derivation_path =
-        BIP84_DERIVATION_PATH.into_derivation_path().expect("valid derivation path");
-    let child_xpriv = master_xpriv.derive_xpriv(secp, &derivation_path);
-    let internal_index = ChildNumber::ONE_NORMAL;
-    let idx = ChildNumber::from_normal_idx(index).expect("valid index number");
 
-    child_xpriv.derive_xpriv(secp, &[internal_index, idx])
+    let derivation_path = BIP84_DERIVATION_PATH.parse::<DerivationPath>().expect("valid path");
+    let child_xpriv = master_xpriv.derive_priv(secp, &derivation_path);
+    let internal_index = ChildKeyIndex::ONE_NORMAL;
+    let idx = ChildKeyIndex::from_normal_index(index).expect("valid index number");
+
+    child_xpriv.derive_priv(secp, [internal_index, idx])
+
 }
 
 // The address to send to.

--- a/bitcoin/examples/taproot-psbt-simple.rs
+++ b/bitcoin/examples/taproot-psbt-simple.rs
@@ -23,7 +23,7 @@
 use std::collections::BTreeMap;
 
 use bitcoin::address::script_pubkey::ScriptBufExt as _;
-use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, IntoDerivationPath, Xpriv, Xpub};
+use bitcoin::bip32::{ChildKeyIndex, DerivationPath, Fingerprint, Xpriv, Xpub};
 use bitcoin::key::UntweakedPublicKey;
 use bitcoin::locktime::absolute;
 use bitcoin::psbt::Input;
@@ -57,13 +57,13 @@ fn get_external_address_xpriv<C: Signing>(
     master_xpriv: Xpriv,
     index: u32,
 ) -> Xpriv {
-    let derivation_path =
-        BIP86_DERIVATION_PATH.into_derivation_path().expect("valid derivation path");
+    let derivation_path = BIP86_DERIVATION_PATH.parse::<DerivationPath>().expect("valid path");
     let child_xpriv = master_xpriv.derive_xpriv(secp, &derivation_path);
-    let external_index = ChildNumber::ZERO_NORMAL;
-    let idx = ChildNumber::from_normal_idx(index).expect("valid index number");
+    let external_index = ChildKeyIndex::ZERO_NORMAL;
+    let idx = ChildKeyIndex::from_normal_index(index).expect("valid index number");
 
-    child_xpriv.derive_xpriv(secp, &[external_index, idx])
+    child_xpriv.derive_xpriv(secp, [external_index, idx])
+
 }
 
 // Derive the internal address xpriv.
@@ -72,13 +72,13 @@ fn get_internal_address_xpriv<C: Signing>(
     master_xpriv: Xpriv,
     index: u32,
 ) -> Xpriv {
-    let derivation_path =
-        BIP86_DERIVATION_PATH.into_derivation_path().expect("valid derivation path");
+    let derivation_path = BIP86_DERIVATION_PATH.parse::<DerivationPath>().expect("valid path");
     let child_xpriv = master_xpriv.derive_xpriv(secp, &derivation_path);
-    let internal_index = ChildNumber::ONE_NORMAL;
-    let idx = ChildNumber::from_normal_idx(index).expect("valid index number");
+    let internal_index = ChildKeyIndex::ONE_NORMAL;
+    let idx = ChildKeyIndex::from_normal_index(index).expect("valid index number");
 
-    child_xpriv.derive_xpriv(secp, &[internal_index, idx])
+    child_xpriv.derive_xpriv(secp, [internal_index, idx])
+
 }
 
 // Get the Taproot Key Origin.

--- a/bitcoin/src/psbt/map/global.rs
+++ b/bitcoin/src/psbt/map/global.rs
@@ -3,7 +3,7 @@
 use internals::ToU64 as _;
 use io::{BufRead, Cursor, Read};
 
-use crate::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpub};
+use crate::bip32::{ChildKeyIndex, DerivationPath, Fingerprint, Xpub};
 use crate::consensus::encode::MAX_VEC_SIZE;
 use crate::consensus::{encode, Decodable};
 use crate::prelude::{btree_map, BTreeMap, Vec};
@@ -44,7 +44,7 @@ impl Map for Psbt {
                 value: {
                     let mut ret = Vec::with_capacity(4 + derivation.len() * 4);
                     ret.extend(fingerprint.as_bytes());
-                    derivation.into_iter().for_each(|n| ret.extend(&u32::from(*n).to_le_bytes()));
+                    derivation.into_iter().for_each(|n| ret.extend(&u32::from(n).to_le_bytes()));
                     ret
                 },
             });
@@ -130,9 +130,9 @@ impl Psbt {
                                 decoder.read_exact(&mut fingerprint[..]).map_err(|_| {
                                     Error::XPubKey("can't read global xpub fingerprint")
                                 })?;
-                                let mut path = Vec::<ChildNumber>::with_capacity(child_count);
+                                let mut path = Vec::<ChildKeyIndex>::with_capacity(child_count);
                                 while let Ok(index) = u32::consensus_decode(&mut decoder) {
-                                    path.push(ChildNumber::from(index))
+                                    path.push(ChildKeyIndex::from(index))
                                 }
                                 let derivation = DerivationPath::from(path);
                                 // Keys, according to BIP-174, must be unique

--- a/bitcoin/src/psbt/serialize.rs
+++ b/bitcoin/src/psbt/serialize.rs
@@ -9,7 +9,7 @@ use hashes::{hash160, ripemd160, sha256, sha256d};
 use secp256k1::XOnlyPublicKey;
 
 use super::map::{Input, Map, Output, PsbtSighashType};
-use crate::bip32::{ChildNumber, Fingerprint, KeySource};
+use crate::bip32::{ChildKeyIndex, Fingerprint, KeySource};
 use crate::consensus::encode::{self, deserialize_partial, serialize, Decodable, Encodable};
 use crate::crypto::key::PublicKey;
 use crate::crypto::{ecdsa, taproot};
@@ -203,8 +203,8 @@ impl Serialize for KeySource {
 
         rv.append(&mut self.0.to_byte_array().to_vec());
 
-        for cnum in self.1.into_iter() {
-            rv.append(&mut serialize(&u32::from(*cnum)))
+        for cnum in (&self.1).into_iter() {
+            rv.append(&mut serialize(&u32::from(cnum)))
         }
 
         rv
@@ -218,7 +218,7 @@ impl Deserialize for KeySource {
         }
 
         let fprint: Fingerprint = bytes[0..4].try_into().expect("4 is the fingerprint length");
-        let mut dpath: Vec<ChildNumber> = Default::default();
+        let mut dpath: Vec<ChildKeyIndex> = Default::default();
 
         let mut d = &bytes[4..];
         while !d.is_empty() {
@@ -395,7 +395,7 @@ impl Deserialize for TapTree {
 }
 
 // Helper function to compute key source len
-fn key_source_len(key_source: &KeySource) -> usize { 4 + 4 * (key_source.1).as_ref().len() }
+fn key_source_len(key_source: &KeySource) -> usize { 4 + 4 * (key_source.1).len() }
 
 #[cfg(test)]
 mod tests {

--- a/bitcoin/tests/serde.rs
+++ b/bitcoin/tests/serde.rs
@@ -25,7 +25,7 @@
 use std::collections::BTreeMap;
 
 use bincode::serialize;
-use bitcoin::bip32::{ChildNumber, KeySource, Xpriv, Xpub};
+use bitcoin::bip32::{ChildKeyIndex, KeySource, Xpriv, Xpub};
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 use bitcoin::hex::FromHex;
@@ -194,7 +194,7 @@ fn serde_regression_control_block() {
 
 #[test]
 fn serde_regression_child_number() {
-    let num = ChildNumber::Normal { index: 0xDEADBEEF };
+    let num = ChildKeyIndex::from(0xDEADBEEF);
     let got = serialize(&num).unwrap();
     let want = include_bytes!("data/serde/child_number_bincode") as &[_];
     assert_eq!(got, want)


### PR DESCRIPTION
The BIP32 API had several problems that we wanted to fix for some time. It didn't protect the invariants of child numbers, had some methods fallible even if the errors were cryptographically impossible, it lacked infallible APIs for deriving xpubs when absence of hardened children was statically known, and had annoying ChildNumber enum with named field for no good reason.

In this commit we do a bunch of refactoring to fix these problems. We add newtypes for the child numbers and a newtype for derivation path that is guaranteed to only contain normal child numbers with appropriate parsing and conversion methods. We refactor the ChildNumber enum to use tuple variants containing the newtypes and fix the infallible APIs to not return Result. Dealing with hardened child numbers can still be annoying or non-performant in some scenarios so we still provide a fallible derivation method. Further we put the newtypes into separate submodules to make accidental breaking of invariatns less likely.